### PR TITLE
Migrate deprecated Sass '@import's to '@use'

### DIFF
--- a/src/app/course-category-combobox/course-category-combobox.component.scss
+++ b/src/app/course-category-combobox/course-category-combobox.component.scss
@@ -1,6 +1,5 @@
-@import "../../styles/button";
-@import "../../styles/forms";
+@use "../../styles/button" as button;
+@use "../../styles/forms" as forms;
 
-@include buttonStyles();
-@include formStyles();
-
+@include button.buttonStyles();
+@include forms.formStyles();

--- a/src/app/course/course.component.scss
+++ b/src/app/course/course.component.scss
@@ -1,6 +1,4 @@
 
-@import "../../styles/table";
-
 .course-container {
   max-width: 400px;
   margin: 0 auto;

--- a/src/app/courses-card-list/courses-card-list.component.scss
+++ b/src/app/courses-card-list/courses-card-list.component.scss
@@ -1,6 +1,6 @@
-@import "../../styles/button";
+@use "../../styles/button" as button;
 
-@include buttonStyles();
+@include button.buttonStyles();
 
 .course-card {
   margin: 20px 10px;

--- a/src/app/edit-course-dialog/edit-course-dialog.component.scss
+++ b/src/app/edit-course-dialog/edit-course-dialog.component.scss
@@ -1,8 +1,8 @@
-@import "../../styles/button";
-@import "../../styles/forms";
+@use "../../styles/button" as button;
+@use "../../styles/forms" as forms;
 
-@include buttonStyles();
-@include formStyles();
+@include button.buttonStyles();
+@include forms.formStyles();
 
 .edit-course-form {
   display: flex;

--- a/src/app/home/home.component.scss
+++ b/src/app/home/home.component.scss
@@ -1,6 +1,6 @@
-@import "../../styles/button";
+@use "../../styles/button" as button;
 
-@include buttonStyles();
+@include button.buttonStyles();
 
 .courses-panel {
   max-width: 400px;

--- a/src/app/lessons/lesson-detail/lesson-detail.component.scss
+++ b/src/app/lessons/lesson-detail/lesson-detail.component.scss
@@ -1,9 +1,8 @@
-@import "../../../styles/button";
-@import "../../../styles/forms";
+@use "../../../styles/button" as button;
+@use "../../../styles/forms" as forms;
 
-@include buttonStyles();
-@include formStyles();
-
+@include button.buttonStyles();
+@include forms.formStyles();
 
 .lesson-detail {
   max-width: 600px;

--- a/src/app/lessons/lessons.component.scss
+++ b/src/app/lessons/lessons.component.scss
@@ -1,9 +1,8 @@
-@import "../../styles/button";
-@import "../../styles/forms";
-@import "../../styles/table";
+@use "../../styles/button" as button;
+@use "../../styles/forms" as forms;
 
-@include buttonStyles();
-@include formStyles();
+@include button.buttonStyles();
+@include forms.formStyles();
 
 .lessons {
   max-width: 400px;

--- a/src/app/linked-signal/linked-signal-demo.component.scss
+++ b/src/app/linked-signal/linked-signal-demo.component.scss
@@ -1,9 +1,8 @@
+@use "../../styles/button" as button;
+@use "../../styles/forms" as forms;
 
-@import "../../styles/button";
-@import "../../styles/forms";
-
-@include buttonStyles();
-@include formStyles();
+@include button.buttonStyles();
+@include forms.formStyles();
 
 .demo-container {
   max-width: 400px;

--- a/src/app/login/login.component.scss
+++ b/src/app/login/login.component.scss
@@ -1,8 +1,8 @@
-@import "../../styles/forms";
-@import "../../styles/button";
+@use "../../styles/button" as button;
+@use "../../styles/forms" as forms;
 
-@include formStyles();
-@include buttonStyles();
+@include button.buttonStyles();
+@include forms.formStyles();
 
 .login-form {
   display: flex;

--- a/src/app/resource-demo/resource-demo.component.scss
+++ b/src/app/resource-demo/resource-demo.component.scss
@@ -1,9 +1,8 @@
-@import "../../styles/button";
-@import "../../styles/forms";
-@import "../../styles/table";
+@use "../../styles/button" as button;
+@use "../../styles/forms" as forms;
 
-@include buttonStyles();
-@include formStyles();
+@include button.buttonStyles();
+@include forms.formStyles();
 
 .demo-container {
   max-width: 400px;


### PR DESCRIPTION
The SCSS '@import's generate a deprecated warning from 'ng'; see [sass-lang](https://sass-lang.com/documentation/breaking-changes/import/) for details. This PR migrates the '@import's to '@use' with a namespace. It also remove superfluous imports.
